### PR TITLE
Move over to `webls` and clean it all up

### DIFF
--- a/server/gleam.toml
+++ b/server/gleam.toml
@@ -32,6 +32,7 @@ lustre = ">= 4.3.1 and < 5.0.0"
 xmleam = ">= 1.1.5 and < 2.0.0"
 birl = ">= 1.7.1 and < 2.0.0"
 gleesend = ">= 1.0.3 and < 2.0.0"
+webls = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/server/gleam.toml
+++ b/server/gleam.toml
@@ -32,7 +32,7 @@ lustre = ">= 4.3.1 and < 5.0.0"
 xmleam = ">= 1.1.5 and < 2.0.0"
 birl = ">= 1.7.1 and < 2.0.0"
 gleesend = ">= 1.0.3 and < 2.0.0"
-webls = ">= 1.0.0 and < 2.0.0"
+webls = ">= 1.1.1 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/server/manifest.toml
+++ b/server/manifest.toml
@@ -52,6 +52,7 @@ packages = [
   { name = "ssl_verify_fun", version = "1.1.7", build_tools = ["mix", "rebar3", "make"], requirements = [], otp_app = "ssl_verify_fun", source = "hex", outer_checksum = "FE4C190E8F37401D30167C8C405EDA19469F34577987C76DDE613E838BBC67F8" },
   { name = "thoas", version = "1.2.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "E38697EDFFD6E91BD12CEA41B155115282630075C2A727E7A6B2947F5408B86A" },
   { name = "unicode_util_compat", version = "0.7.0", build_tools = ["rebar3"], requirements = [], otp_app = "unicode_util_compat", source = "hex", outer_checksum = "25EEE6D67DF61960CF6A794239566599B09E17E668D3700247BC498638152521" },
+  { name = "webls", version = "1.0.0", build_tools = ["gleam"], requirements = ["birl", "gleam_stdlib"], otp_app = "webls", source = "hex", outer_checksum = "1CBFE1537D2204920A2561BA8C7CEDE2AA70F5210F10F0A96F94EEBCC7959A6A" },
   { name = "wisp", version = "0.16.0", build_tools = ["gleam"], requirements = ["exception", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_stdlib", "logging", "marceau", "mist", "simplifile"], otp_app = "wisp", source = "hex", outer_checksum = "A13DAD6A84BED78FF5D7656F3B5125086801BE1AF47427A9A759EA8C484345AB" },
   { name = "xmleam", version = "1.1.5", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "xmleam", source = "hex", outer_checksum = "4D69B1074781E9EE335A9C0EBC56C228890940F80E18D6A1B024C2C97BFF52AB" },
 ]
@@ -75,5 +76,6 @@ lustre = { version = ">= 4.3.1 and < 5.0.0" }
 mist = { version = ">= 1.2.0 and < 2.0.0" }
 prng = { version = ">= 3.0.3 and < 4.0.0" }
 shared = { path = "../shared" }
+webls = { version = ">= 1.0.0 and < 2.0.0" }
 wisp = { version = ">= 0.16.0 and < 1.0.0" }
 xmleam = { version = ">= 1.1.5 and < 2.0.0" }

--- a/server/manifest.toml
+++ b/server/manifest.toml
@@ -52,7 +52,7 @@ packages = [
   { name = "ssl_verify_fun", version = "1.1.7", build_tools = ["mix", "rebar3", "make"], requirements = [], otp_app = "ssl_verify_fun", source = "hex", outer_checksum = "FE4C190E8F37401D30167C8C405EDA19469F34577987C76DDE613E838BBC67F8" },
   { name = "thoas", version = "1.2.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "E38697EDFFD6E91BD12CEA41B155115282630075C2A727E7A6B2947F5408B86A" },
   { name = "unicode_util_compat", version = "0.7.0", build_tools = ["rebar3"], requirements = [], otp_app = "unicode_util_compat", source = "hex", outer_checksum = "25EEE6D67DF61960CF6A794239566599B09E17E668D3700247BC498638152521" },
-  { name = "webls", version = "1.0.0", build_tools = ["gleam"], requirements = ["birl", "gleam_stdlib"], otp_app = "webls", source = "hex", outer_checksum = "1CBFE1537D2204920A2561BA8C7CEDE2AA70F5210F10F0A96F94EEBCC7959A6A" },
+  { name = "webls", version = "1.1.1", build_tools = ["gleam"], requirements = ["birl", "gleam_stdlib"], otp_app = "webls", source = "hex", outer_checksum = "9A262DE4CDD9095B74CD5038BA96DAA9828E8E8209BC0D4E982CC4B68C2F8B63" },
   { name = "wisp", version = "0.16.0", build_tools = ["gleam"], requirements = ["exception", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_stdlib", "logging", "marceau", "mist", "simplifile"], otp_app = "wisp", source = "hex", outer_checksum = "A13DAD6A84BED78FF5D7656F3B5125086801BE1AF47427A9A759EA8C484345AB" },
   { name = "xmleam", version = "1.1.5", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "xmleam", source = "hex", outer_checksum = "4D69B1074781E9EE335A9C0EBC56C228890940F80E18D6A1B024C2C97BFF52AB" },
 ]
@@ -76,6 +76,6 @@ lustre = { version = ">= 4.3.1 and < 5.0.0" }
 mist = { version = ">= 1.2.0 and < 2.0.0" }
 prng = { version = ">= 3.0.3 and < 4.0.0" }
 shared = { path = "../shared" }
-webls = { version = ">= 1.0.0 and < 2.0.0" }
+webls = { version = ">= 1.1.1 and < 2.0.0" }
 wisp = { version = ">= 0.16.0 and < 1.0.0" }
 xmleam = { version = ">= 1.1.5 and < 2.0.0" }

--- a/server/src/server/routes/robots.gleam
+++ b/server/src/server/routes/robots.gleam
@@ -1,8 +1,16 @@
+import webls/robots.{Robot, RobotsConfig}
 import wisp.{type Response}
 
 pub fn robots_txt() -> Response {
+  let config =
+    RobotsConfig(sitemap_url: "https://kirakira.keii.dev/sitemap.xml", robots: [
+      Robot(
+        user_agent: "*",
+        disallowed_routes: ["/auth", "/user", "/api"],
+        allowed_routes: ["/"],
+      ),
+    ])
+
   wisp.response(200)
-  |> wisp.string_body(
-    "User-agent: *\nDisallow: /auth\nDisallow: /user\nDisallow: /api\nAllow: /\n \nSitemap: https://kirakira.keii.dev/sitemap.xml\n",
-  )
+  |> wisp.string_body(config |> robots.to_string())
 }

--- a/server/src/server/routes/sitemap.gleam
+++ b/server/src/server/routes/sitemap.gleam
@@ -1,115 +1,94 @@
 import birl
 import gleam/int
 import gleam/list
+import gleam/option.{None, Some}
 import gleam/result
-import gleam/string_builder.{type StringBuilder}
-import wisp.{type Response}
-import xmleam/xml_builder.{
-  type BuilderError, type XmlBuilder, ContentsEmpty, block_tag, new, tag,
-}
-
 import server/db/sitemap.{type PostSitemap, get_post_sitemap}
-
-fn new_sitemap(map: StringBuilder) -> XmlBuilder {
-  string_builder.new()
-  |> string_builder.append(
-    "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n",
-  )
-  |> string_builder.append_builder(map)
-  |> string_builder.append("</urlset>\n")
-  |> Ok
-}
+import webls/sitemap.{Sitemap, SitemapItem} as webls_sitemap
+import wisp.{type Response}
 
 pub fn sitemap_xml() -> Response {
   let posts: List(PostSitemap) = get_post_sitemap()
 
-  let post_map: Result(StringBuilder, BuilderError) = {
-    case
-      list.map(posts, fn(post) {
-        let post_updated_at: Int =
-          post.comments_at
-          |> list.reduce(fn(acc, x) {
-            case acc < x {
-              True -> x
-              False -> acc
-            }
-          })
-          |> result.unwrap(post.created_at)
-
-        new()
-        |> block_tag("url", {
-          new()
-          |> tag(
-            "loc",
-            "https://kirakira.keii.dev/post/" <> int.to_string(post.id),
-          )
-          |> tag(
-            "lastmod",
-            post_updated_at
-              |> birl.from_unix
-              |> birl.to_iso8601,
-          )
-          |> tag("changefreq", case
-            // if the post was updated less than a day ago, set it to daily
-            { { { birl.now() |> birl.to_unix() } - post_updated_at } > 86_400 }
-          {
-            False -> "daily"
-            True -> "weekly"
-          })
-          |> tag("priority", {
-            let inactive: Bool =
-              { { birl.now() |> birl.to_unix() } - post_updated_at } > 864_000
-            case inactive {
-              True -> "0.5"
-              False -> "0.7"
-            }
-          })
+  let post_pages =
+    posts
+    |> list.map(fn(post) {
+      let updated_at: Int =
+        post.comments_at
+        |> list.reduce(fn(acc, x) {
+          case acc < x {
+            True -> x
+            False -> acc
+          }
         })
-      })
-      |> list.reduce(fn(acc, x) {
-        case acc {
-          Ok(acc) ->
-            case x {
-              Ok(x) -> Ok(acc |> string_builder.append_builder(x))
-              Error(_) -> Error(ContentsEmpty)
-            }
-          Error(_) -> Error(ContentsEmpty)
-        }
-      })
-    {
-      Ok(post_map) -> post_map
-      Error(_) -> Error(ContentsEmpty)
-    }
-  }
+        |> result.unwrap(post.created_at)
 
-  let base_map =
-    new()
-    |> block_tag("url", {
-      new()
-      |> tag("loc", "https://kirakira.keii.dev")
-      |> tag("changefreq", "daily")
-      |> tag("priority", "1.0")
+      SitemapItem(
+        loc: "https://kirakira.keii.dev/post/" <> int.to_string(post.id),
+        last_modified: Some(
+          updated_at
+          |> birl.from_unix,
+        ),
+        change_frequency: Some(case
+          // if the post was updated less than a day ago, set it to daily
+          { { { birl.now() |> birl.to_unix() } - updated_at } > 86_400 }
+        {
+          False -> webls_sitemap.Daily
+          True -> webls_sitemap.Weekly
+        }),
+        priority: Some(case
+          // if the post was updated more than ten days ago, set it to inactive
+          { { birl.now() |> birl.to_unix() } - updated_at } > 864_000
+        {
+          True -> 0.5
+          False -> 0.7
+        }),
+      )
     })
 
-  let full_map: Result(StringBuilder, BuilderError) = case base_map {
-    Ok(base_map) ->
-      case post_map {
-        Ok(post_map) -> Ok(base_map |> string_builder.append_builder(post_map))
-        Error(_) -> Error(ContentsEmpty)
-      }
-    Error(_) -> Error(ContentsEmpty)
-  }
+  let sitemap =
+    Sitemap(
+      url: "https://kirakira.keii.dev",
+      last_modified: Some(birl.now()),
+      items: [
+        // the homepage feed
+        SitemapItem(
+          loc: "https://kirakira.keii.dev",
+          last_modified: Some(
+            posts
+            |> list.map(fn(post) {
+              post.comments_at
+              |> list.reduce(fn(acc, x) {
+                case acc < x {
+                  True -> x
+                  False -> acc
+                }
+              })
+              |> result.unwrap(post.created_at)
+            })
+            |> list.reduce(fn(acc, x) {
+              case acc < x {
+                True -> x
+                False -> acc
+              }
+            })
+            |> result.unwrap(birl.now() |> birl.to_unix)
+            |> birl.from_unix,
+          ),
+          change_frequency: Some(webls_sitemap.Daily),
+          priority: Some(1.0),
+        ),
+        SitemapItem(
+          loc: "https://kirakira.keii.dev/auth/login",
+          last_modified: None,
+          change_frequency: None,
+          priority: None,
+        ),
+        ..post_pages
+      ],
+    )
 
-  case full_map {
-    Ok(full_map) -> {
-      case full_map |> new_sitemap {
-        Ok(sitemap) ->
-          wisp.response(200)
-          |> wisp.set_header("Content-Type", "text/xml")
-          |> wisp.string_builder_body(sitemap)
-        Error(_) -> wisp.response(500)
-      }
-    }
-    Error(_) -> wisp.response(500)
-  }
+  wisp.response(200)
+  |> wisp.set_header("Content-Type", "text/xml")
+  |> wisp.string_body(sitemap |> webls_sitemap.to_string)
 }


### PR DESCRIPTION
massively cleans up mess of string builders and error handling to instead use `webls` which will also be used for the rss feed

<img width="1397" alt="Screenshot 2024-08-08 at 10 45 14 PM" src="https://github.com/user-attachments/assets/3bcefa1b-b754-49d2-9776-572325ad42ae">
